### PR TITLE
Make exchanges import relative

### DIFF
--- a/btsfeed/exchanges/__init__.py
+++ b/btsfeed/exchanges/__init__.py
@@ -1,1 +1,1 @@
-from exchanges.exchanges import Exchanges 
+from .exchanges import Exchanges 


### PR DESCRIPTION
Starting bts_feed_auto.py errored as unable to find exchanges module.
Making the import relative fixes the issue. I am using python 2.7.
